### PR TITLE
Check against non-existent input files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _build
 moonbit-lang.install
+.vscode

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ We use `$obj` to indicate path where object files should be generated; they typi
 Compile files with these commands:
 
 ```bash
+bundled=$core/target/$target/release/bundle
+
 # Here, main.mbt should be a file containing `fn main`.
-moonc build-package $src/main.mbt -is-main -std-path $core/target/$target/release/bundle -o $obj -target $target
+moonc build-package $src/main.mbt -is-main -std-path $bundled -o $obj -target $target
 
 # If you have more than one package, remember to include all of them in -pkg-sources. They should be separated by colon ':'.
-moonc link-core $moonbundle/core.core $obj -o $dest -pkg-config-path $src/moon.pkg.json -pkg-sources $core:$src -target $target
+moonc link-core $bundled/core.core $obj -o $dest -pkg-config-path $src/moon.pkg.json -pkg-sources $core:$src -target $target
 ```
 
 Then `$dest` would be available for use.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Building a programming language is a long journey. It took Rust 9 years and Go 5
 - OCaml 4.14.2
 - [OPAM](https://opam.ocaml.org/)
 
+You must update MoonBit to the latest version. Otherwise, `moonc` can fail with segmentation fault, since the binaries of the language core is not compatible.
+
 ### Build
 
 Build with following scripts:
@@ -37,10 +39,29 @@ opam install -y dune
 dune build -p moonbit-lang
 ```
 
+### Usage
+
+MoonBit's core library is typically installed in `~/.moon/lib/core/`. In following commands, we use `$core` to denote the path. Under `$core/target`, there are folders containing pre-built libraries under different targets: `js`, `wasm` and `wasm-gc`. Let `$target` stand for one of these three.
+
+We use `$src` to denote the path to your main package. This package must contain, along with your source files, a `moon.pkg.json`; if you're not sure how this works, you can use [moon](https://github.com/moonbitlang/moon) to initialize a MoonBit repository.
+
+We use `$obj` to indicate path where object files should be generated; they typically carry a suffix `.core`. We use `$dest` to represent target files, which might be `.js` or `.wasm` according to your target choice.
+
+Compile files with these commands:
+
+```bash
+# Here, main.mbt should be a file containing `fn main`.
+moonc build-package $src/main.mbt -is-main -std-path $core/target/$target/release/bundle -o $obj -target $target
+
+# If you have more than one package, remember to include all of them in -pkg-sources. They should be separated by colon ':'.
+moonc link-core $moonbundle/core.core $obj -o $dest -pkg-config-path $src/moon.pkg.json -pkg-sources $core:$src -target $target
+```
+
+Then `$dest` would be available for use.
+
 ## Contributing
 
-The project is evolving extremely fast that it is not yet ready for massive community 
-contributions. 
+The project is evolving extremely fast that it is not yet ready for massive community contributions. 
 
 If you do have interest in contributing, thank you!
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -27,6 +27,8 @@
 - OCaml 4.14.2
 - [OPAM](https://opam.ocaml.org/)
 
+MoonBit 必须升级到最新版本，否则 `moonc` 可能会段错误。这是因为预编译的旧版本 MoonBit 核心可能和编译器不兼容。
+
 ### 构建
 
 使用下列脚本构建
@@ -36,6 +38,26 @@ opam switch create 4.14.2
 opam install -y dune
 dune build -p moonbit-lang
 ```
+
+### 使用
+
+MoonBit 的核心库一般安装在 `~/.moon/lib/core` 下。在下面的命令中，我们会用 `$core` 表示核心库的安装路径。在 `$core/target` 下，有 `js`, `wasm` 和 `wasm-gc` 这三个文件夹，它们包含在对应目标下编译好的核心库。我们用 `$target` 表示这三者之一。
+
+`$src` 表示源代码的路径；在这个文件夹下，除了源代码之外还必须包括一个 `moon.pkg.json`。如果你不清楚如何编写这个文件，可以考虑使用 [moon](https://github.com/moonbitlang/moon) 来初始化。
+
+`$obj` 表示生成中间文件的位置。这些中间文件通常以 `.core` 作为后缀。而 `$dest` 则表示目标文件生成的路径，它们的后缀根据 `$target` 的选择不同而在 `.js` or `.wasm` 中变化。
+
+编译所需的命令如下:
+
+```bash
+# 这里 main.mbt 是一个含有 `fn main` 的文件。
+moonc build-package $src/main.mbt -is-main -std-path $core/target/$target -o $obj -target $target
+
+# 如果有不止一个包，别忘了在 -pkg-sources 里指定所有包的路径。
+moonc link-core $moonbundle/core.core $obj -o $dest -pkg-config-path $src/moon.pkg.json -pkg-sources $core:$src -target $target
+```
+
+执行后，`$dest` 就是编译好的目标代码了。
 
 ## 贡献
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,11 +50,13 @@ MoonBit 的核心库一般安装在 `~/.moon/lib/core` 下。在下面的命令�
 编译所需的命令如下:
 
 ```bash
+bundled=$core/target/$target/release/bundle
+
 # 这里 main.mbt 是一个含有 `fn main` 的文件。
-moonc build-package $src/main.mbt -is-main -std-path $core/target/$target -o $obj -target $target
+moonc build-package $src/main.mbt -is-main -std-path $core/target/$bundled -o $obj -target $target
 
 # 如果有不止一个包，别忘了在 -pkg-sources 里指定所有包的路径。
-moonc link-core $moonbundle/core.core $obj -o $dest -pkg-config-path $src/moon.pkg.json -pkg-sources $core:$src -target $target
+moonc link-core $bundled/core.core $obj -o $dest -pkg-config-path $src/moon.pkg.json -pkg-sources $core:$src -target $target
 ```
 
 执行后，`$dest` 就是编译好的目标代码了。

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,7 @@
 
 ## 路线图
 
-构建一个编程语言是一个漫长的旅程。Rust 和 Go 分别用了 9 年和 5 年到达 1.0 版本。MoonBit 由一个年轻而有干劲的团队开发，正在稳步前进。我们明白，社区的采用和扩展对编程语言来说十分关键，并且我们也致力于打造一个围绕 MoonBit 的积极参与、合作共赢的社区。到目前为止，我们已经开源了[标准库](https://github.com/moonbitlang/core)和绝大多数工具，包括[构建系统](https://github.com/moonbitlang/moon)，[词法分析](https://github.com/moonbit-community/moonlex)，[markdown 解析](https://github.com/moonbit-community/cmark)等，将来还会有更多项目。开放编译器源代码对于安全来说十分重要。开源 Wasm 后端是重要一步，并且我们计划在将来开源更多组建（ moonfmt、moondoc ）。
+构建一个编程语言是一个漫长的旅程。Rust 和 Go 分别用了 9 年和 5 年到达 1.0 版本。MoonBit 由一个年轻而有干劲的团队开发，正在稳步前进。我们明白，社区的采用和扩展对编程语言来说十分关键，并且我们也致力于打造一个围绕 MoonBit 的积极参与、合作共赢的社区。到目前为止，我们已经开源了[标准库](https://github.com/moonbitlang/core)和绝大多数工具，包括[构建系统](https://github.com/moonbitlang/moon)，[词法分析](https://github.com/moonbit-community/moonlex)，[markdown 解析](https://github.com/moonbit-community/cmark)等，将来还会有更多项目。开放编译器源代码对于安全来说十分重要。开源 Wasm 后端是重要一步，并且我们计划在将来开源更多组件（ moonfmt、moondoc ）。
 
 
 ## 从源代码构建

--- a/src/core_format.ml
+++ b/src/core_format.ml
@@ -231,10 +231,11 @@ let of_string (bin : string) : t array =
   else assert false
 
 let import ~(path : string) : t array =
-  if Sys.file_exists path then
+  try
     In_channel.with_open_bin path (fun ic ->
         Stdlib.In_channel.input_all ic |> of_string)
-  else failwith (path ^ " not found")
+  with Sys_error msg ->
+    raise (Arg.Bad ("cannot open file: " ^ path))
 
 let dump_serialized_from_t (t : t array) : S.t =
   let t_to_serialized (t : t) : serialized =
@@ -253,11 +254,14 @@ let bundle ~inputs ~path =
   let pkgs =
     inputs
     |> List.map (fun path ->
-           In_channel.with_open_bin path (fun ic ->
+          try
+            In_channel.with_open_bin path (fun ic ->
                match Basic_config.input_magic_str ic with
                | Some s when String.equal s magic_str ->
                    (Marshal.from_channel ic : serialized array)
-               | _ -> failwith "invalid MoonBit object file"))
+               | _ -> (raise (Arg.Bad ("invalid MoonBit object file: " ^ path))))
+          with Sys_error msg ->
+            raise (Arg.Bad ("cannot open file: " ^ path)))
     |> Array.concat
   in
   Out_channel.with_open_bin path (fun oc ->

--- a/src/driver_util.ml
+++ b/src/driver_util.ml
@@ -51,7 +51,10 @@ let parse ~diagnostics ~(debug_tokens : bool) (input : mbt_input) :
     Parsing_parse.output =
   match input with
   | File_Path path ->
-      Parsing_parse.parse ~diagnostics ~debug_tokens ~transform:false path
+      (try
+        Parsing_parse.parse ~diagnostics ~debug_tokens ~transform:false path
+      with Sys_error msg ->
+        raise (Arg.Bad ("cannot open file: " ^ path)))
   | Name_Content (name, content) ->
       Parsing_parse.impl_of_string ~name ~debug_tokens ~diagnostics
         ~transform:false content

--- a/src/moon0_main.ml
+++ b/src/moon0_main.ml
@@ -43,13 +43,14 @@ and is_main = Driver_config.Common_Opt.is_main
 let moonc_executable_name = "moonc"
 let bundle_core_usage = "moonc bundle-core [options] <input files>"
 let link_core_usage = "moonc link-core [options] <input files>"
-let build_packae_usage = "moonc build-package [options] <input files>"
+let build_package_usage = "moonc build-package [options] <input files>"
 let check_usage = "moonc check [options] <input files>"
 let compile_usage = "moonc compile [options] <input file>"
 let gen_test_info_usage = "moonc gen-test-info [options] <input files>"
 let postprocess_ast = Driver_util.postprocess_ast ~diagnostics
 let write_s name sexp = if not !no_intermediate_file then Io.write_s name sexp
 
+(* TAST here stands for typed AST *)
 let tast_of_ast ~name ~build_context (asts : Parse.output list) :
     Typedtree.output * Global_env.t =
   let write_opt suffix sexp = write_s (name ^ suffix) sexp in
@@ -212,9 +213,9 @@ let build_package () =
   let build_package_spec = Driver_config.Buildpkg_Opt.spec in
   Arg.parse_argv ~current:(ref 1) Sys.argv build_package_spec
     (fun input_file -> input_files := input_file :: !input_files)
-    build_packae_usage;
+    build_package_usage;
   if !input_files = [] && !output_file = "" then (
-    Arg.usage build_package_spec build_packae_usage;
+    Arg.usage build_package_spec build_package_usage;
     exit 0);
   if !output_file = "" then
     output_file := Filename.basename !Basic_config.current_package ^ ".core";
@@ -345,7 +346,7 @@ let compile () =
                     (Sys.executable_name :: String.split_on_char ' ' d)
                 in
                 (try Arg.parse_argv build_flags spec ignore ""
-                 with Arg.Bad s -> prerr_string s);
+                 with Arg.Bad s -> prerr_endline s);
                 ())
       in
       let ast =
@@ -476,7 +477,7 @@ let run_main () =
           (try command () with
           | Arg.Help s -> print_string s
           | Arg.Bad s ->
-              prerr_string s;
+              prerr_endline s;
               exit 2
           | Diagnostics.Fatal_error -> exit 2);
           Driver_compenv.exec_args after
@@ -490,7 +491,7 @@ let run_main () =
                     exit 0),
                 " show version" );
             ]
-            (fun name -> raise (Arg.Bad ("Dont'know what to do with " ^ name)))
+            (fun name -> raise (Arg.Bad ("Don't know what to do with " ^ name)))
             moonc_executable_name;
           exit 2
 

--- a/src/parsing_parse.ml
+++ b/src/parsing_parse.ml
@@ -123,6 +123,9 @@ let impl_of_string ~diagnostics ?name ?(debug_tokens = false) ?directive_handler
 
 let parse ~diagnostics ?(debug_tokens = false) ?directive_handler ~transform
     path =
-  In_channel.with_open_bin path In_channel.input_all
-  |> impl_of_string ~diagnostics ~debug_tokens ~transform ?directive_handler
-       ~name:(Filename.basename path)
+  try
+    In_channel.with_open_bin path In_channel.input_all
+    |> impl_of_string ~diagnostics ~debug_tokens ~transform ?directive_handler
+        ~name:(Filename.basename path)
+  with Sys_error msg ->
+    raise (Arg.Bad ("cannot open file: " ^ path))

--- a/src/stype.ml
+++ b/src/stype.ml
@@ -277,7 +277,9 @@ let extract_tpath t =
   | _ -> None
 
 let extract_tpath_exn t =
-  match extract_tpath t with Some p -> p | None -> failwith __FUNCTION__
+  match extract_tpath t with
+  | Some p -> p
+  | None -> print_endline "bad"; failwith __FUNCTION__
 
 let arity_of_typ t =
   match t with


### PR DESCRIPTION
Currently, if an input file cannot be opened, then an ICE is triggered.

For example, if `a` is non-existent, or it is a folder, then
```
moonc build-package a
```
would cause an internal error.

This pull request adds check against it.

