### PR TITLE
Add support for ref.i31 for inline wasm strings

### DIFF
--- a/src/dwarfsm_ast.ml
+++ b/src/dwarfsm_ast.ml
@@ -1413,6 +1413,7 @@ type instr =
   | Ref_func of funcidx
   | Ref_is_null
   | Ref_null of heaptype
+  | Ref_i31
   | Return
   | Struct_get of typeidx * fieldidx
   | Struct_new of typeidx
@@ -2114,6 +2115,8 @@ include struct
 
       method visit_Ref_is_null : _ -> instr = fun env -> Ref_is_null
 
+      method visit_Ref_i31 : _ -> instr = fun env -> Ref_i31
+
       method visit_Ref_null : _ -> heaptype -> instr =
         fun env ->
           fun _visitors_c0 ->
@@ -2460,6 +2463,7 @@ include struct
            | Ref_func _visitors_c0 -> self#visit_Ref_func env _visitors_c0
            | Ref_is_null -> self#visit_Ref_is_null env
            | Ref_null _visitors_c0 -> self#visit_Ref_null env _visitors_c0
+           | Ref_i31 -> self#visit_Ref_i31 env
            | Return -> self#visit_Return env
            | Struct_get (_visitors_c0, _visitors_c1) ->
                self#visit_Struct_get env _visitors_c0 _visitors_c1
@@ -3237,6 +3241,9 @@ include struct
               equal_heaptype _a__301_ _b__302_
           | Ref_null _, _ -> false
           | _, Ref_null _ -> false
+          | Ref_i31, Ref_i31 -> true
+          | Ref_i31, _ -> false
+          | _, Ref_i31 -> false
           | Return, Return -> true
           | Return, _ -> false
           | _, Return -> false

--- a/src/dwarfsm_encode_wasm.ml
+++ b/src/dwarfsm_encode_wasm.ml
@@ -556,6 +556,7 @@ struct
     | Ref_func x -> byte 0xd2 ^^ funcidx x
     | Ref_is_null -> byte 0xd1
     | Ref_null t -> byte 0xd0 ^^ heaptype t
+    | Ref_i31 -> byte 0xfb1c
     | Return -> byte 0x0f
     | Struct_get (x, y) -> byte 0xfb ^^ int_uleb128 2 ^^ structandfieldidx x y
     | Struct_new x -> byte 0xfb ^^ int_uleb128 0 ^^ typeidx x

--- a/src/dwarfsm_parse.ml
+++ b/src/dwarfsm_parse.ml
@@ -838,6 +838,7 @@ let rec plaininstr : W.t list -> instr * W.t list = function
   | (Atom "ref.func" : W.t) :: (w : W.t) :: v -> (Ref_func (funcidx w), v)
   | (Atom "ref.is_null" : W.t) :: v -> (Ref_is_null, v)
   | (Atom "ref.null" : W.t) :: (w : W.t) :: v -> (Ref_null (heaptype w), v)
+  | (Atom "ref.i31" : W.t) :: v -> (Ref_i31, v)
   | (Atom "return" : W.t) :: v -> (Return, v)
   | (Atom "struct.get" : W.t) :: (w : W.t) :: (w2 : W.t) :: v ->
       (Struct_get (typeidx w, fieldidx w2), v)


### PR DESCRIPTION
WIP as I haven't tested this yet as I'm having trouble with my opam so I can't switch versions.

This is the instruction for creating an i31 ref. `(ref.i31 (i32.const 1337))`.