### PR TITLE
fix: skip is_simple_stub for closures on wasm-gc

### DIFF
--- a/src/typeutil.ml
+++ b/src/typeutil.ml
@@ -1001,6 +1001,8 @@ let check_stub_type ~(language : string option) (typ : Typedtree.typ)
        | Tarrow { is_async; _ } when (not allow_func) || is_async ->
            Some (Errors.invalid_stub_type loc)
        | Tarrow { params_ty; ret_ty; err_ty; is_async = _ } ->
+           if !Basic_config.target = Wasm_gc then None
+           else
            let is_simple_stub (ty : Stype.t) =
              match Stype.type_repr ty with
              | T_builtin T_unit


### PR DESCRIPTION
## Summary

- On wasm-gc, closures passed to FFI stubs are `externref` regardless of their internal type signatures. Skip `is_simple_stub` validation for arrow types when target is `Wasm_gc`.

Fixes: https://github.com/moonbitlang/moonbit-docs/issues/1131

## Root Cause

`check_stub_type` in `typeutil.ml` validates types inside closure signatures via `is_simple_stub` (lines 1004–1031), which is more restrictive than the top-level validation — but shouldn't need to be, since closures are just `externref` on wasm-gc.

### String

```ocaml
(* Top-level: line 969-972 — String is ALLOWED on wasm-gc imports *)
| T_builtin T_string ->
    if is_import_stub && !Basic_config.target <> Wasm_gc then
      Some error    (* only errors if target is NOT Wasm_gc *)
    else None

(* is_simple_stub: line 1019 — String is REJECTED on ALL imports *)
| T_builtin T_string | T_builtin T_bytes -> not is_import_stub
                                          (* no wasm-gc exception! *)
```

### Enums (e.g. `NotificationPermission`)

```ocaml
(* Top-level: lines 997-999 — enums with no-arg constructors are OK *)
| Some { ty_desc = Variant_type constrs; _ }
  when Lst.for_all constrs (fun c -> c.cs_args = []) -> None

(* is_simple_stub: lines 1024-1027 — only Extern_type is OK *)
| T_constr { type_constructor = p; _ } ->
    match Global_env.find_type_by_path global_env p with
    | Some { ty_desc = Extern_type; _ } -> true
    | _ -> false    (* enums rejected! *)
```

### Why it doesn't matter

On wasm-gc, a closure in an FFI stub becomes `externref`. The wasm import signature is `(func (param externref) (result externref))` regardless of the MoonBit-level closure type. The types inside the closure are a MoonBit-level concern — they only matter when JS calls the closure back. They're irrelevant to the wasm import signature.

## Fix

When `!Basic_config.target = Wasm_gc`, return `None` immediately for arrow types, skipping `is_simple_stub` entirely. This matches the existing wasm-gc special-casing pattern for `T_string` at line 970.

## Test plan

- [ ] Verify closures with `String`, `Array[T]`, and enum params/returns compile in wasm-gc stubs
- [ ] Verify non-wasm-gc targets still validate closure internals via `is_simple_stub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)